### PR TITLE
feat: Add graphviz version options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,7 +16,8 @@ jobs:
         version: 16.x
     - name: Install Dependencies
       run: yarn install
-    - name: Lint
+    - if: matrix.os == 'windows-latest'
+      name: Lint
       run: yarn lint
     - name: Test
       run: yarn test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,7 +16,7 @@ jobs:
         version: 16.x
     - name: Install Dependencies
       run: yarn install
-    - if: matrix.os == 'windows-latest'
+    - if: matrix.os != 'windows-latest'
       name: Lint
       run: yarn lint
     - name: Test

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,4 +4,4 @@ semi: true
 trailingComma: all
 printWidth: 120
 bracketSpacing: true
-endOfLine: auto
+endOfLine: lf

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ GitHub Action to set up Graphviz cross-platform(Linux, macOS, Windows).
 
 ## Example usage
 
+With `ts-graphviz/setup-graphviz`, you can set up a GitHub Action environment
+that allows you to use `Graphviz` on all operating systems.
+
 ```yml
 name: Graphviz CI
 on: [push]
@@ -23,6 +26,21 @@ jobs:
       uses: ts-graphviz/setup-graphviz@v1
     ...
     # In the steps below this you can use Graphviz dot command.
+```
+
+If you want a fixed version of Graphviz,
+you can specify a specific version for each operating system (not macOS).
+
+```yaml
+- name: Setup Graphviz
+  uses: ts-graphviz/setup-graphviz@v1
+  with:
+    # graphviz version on Ubuntu.
+    ubuntu-graphviz-version: '2.42.2-3build2'
+    # libgraphviz-dev version on Ubuntu.
+    ubuntu-libgraphvizdev-version: '2.42.2-3build2'
+    #  graphviz version on Windows.
+    windows-graphviz-version: '2.49.3'
 ```
 
 ## See Also

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,24 @@ author: kamiazya <yuki@kamiazya.tech>
 branding:
   icon: arrow-down-circle
   color: gray-dark
+inputs:
+  ubuntu-graphviz-version:
+    description: |-
+      Graphviz version on Ubuntu.
+    required: false
+  ubuntu-libgraphvizdev-version:
+    description: |-
+      libgraphviz-dev version on Ubuntu.
+    required: false
+  macos-graphviz-version:
+    description: |-
+      Graphviz version on macOS.
+    required: false
+  windows-graphviz-version:
+    description: |-
+      Graphviz version on Windows.
+    required: false
+
 runs:
   using: node16
   main: lib/main.js

--- a/action.yaml
+++ b/action.yaml
@@ -7,19 +7,15 @@ branding:
 inputs:
   ubuntu-graphviz-version:
     description: |-
-      Graphviz version on Ubuntu.
+      graphviz version on Ubuntu.
     required: false
   ubuntu-libgraphvizdev-version:
     description: |-
       libgraphviz-dev version on Ubuntu.
     required: false
-  macos-graphviz-version:
-    description: |-
-      Graphviz version on macOS.
-    required: false
   windows-graphviz-version:
     description: |-
-      Graphviz version on Windows.
+      graphviz version on Windows.
     required: false
 
 runs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graphviz",
-  "version": "1.1.0-1",
+  "version": "1.0.1",
   "author": "kamiazya <yuki@kamiazya.tech>",
   "description": "Setup a graphviz environment.",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "setup"
   ],
   "scripts": {
-    "lint": "eslint src && prettier --check src/**/*.ts",
+    "lint": "eslint src && prettier --check --debug-check src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
     "build": "tsc",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "setup"
   ],
   "scripts": {
-    "lint": "eslint src && prettier --check --debug-check src/**/*.ts",
+    "lint": "eslint src && prettier --check src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
     "build": "tsc",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graphviz",
-  "version": "1.0.1",
+  "version": "1.1.0-0",
   "author": "kamiazya <yuki@kamiazya.tech>",
   "description": "Setup a graphviz environment.",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-graphviz",
-  "version": "1.1.0-0",
+  "version": "1.1.0-1",
   "author": "kamiazya <yuki@kamiazya.tech>",
   "description": "Setup a graphviz environment.",
   "private": true,

--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -1,3 +1,4 @@
+import { getInput } from '@actions/core';
 import { exec } from '@actions/exec';
 
 export class GraphvizInstaller {
@@ -21,23 +22,34 @@ export class GraphvizInstaller {
   }
 
   private async brewInstall() {
+    const graphvizVersion = getInput('macos-graphviz-version');
     await exec('brew', ['update']);
-    await exec('brew', ['install', 'graphviz']);
+    await exec('brew', [
+      'install',
+      graphvizVersion ? `graphviz@${graphvizVersion}` : 'graphviz',
+    ]);
   }
 
   private async getAptInstall() {
+    const graphvizVersion = getInput('ubuntu-graphviz-version');
+    const libgraphvizdevVersion = getInput('ubuntu-libgraphvizdev-version');
     await exec('sudo', ['apt-get', 'update']);
     await exec('sudo', [
       'apt-get',
       'install',
-      'graphviz',
+      graphvizVersion ? `graphviz=${graphvizVersion}` : 'graphviz',
       // https://github.com/pygraphviz/pygraphviz/issues/163#issuecomment-570770201
-      'libgraphviz-dev',
+      libgraphvizdevVersion ? `libgraphviz-dev=${libgraphvizdevVersion}` : 'libgraphviz-dev',
       'pkg-config',
     ]);
   }
 
   private async chocoInstall() {
-    await exec('choco', ['install', 'graphviz']);
+    const graphvizVersion = getInput('window-graphviz-version');
+    await exec('choco', [
+      'install',
+      'graphviz',
+      ...(graphvizVersion ? [`--version=${graphvizVersion}`]: [])
+    ]);
   }
 }

--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -22,11 +22,10 @@ export class GraphvizInstaller {
   }
 
   private async brewInstall() {
-    const graphvizVersion = getInput('macos-graphviz-version');
     await exec('brew', ['update']);
     await exec('brew', [
       'install',
-      graphvizVersion ? `graphviz@${graphvizVersion}` : 'graphviz',
+      'graphviz',
     ]);
   }
 

--- a/src/__tests__/GraphvizInstaller.spec.ts
+++ b/src/__tests__/GraphvizInstaller.spec.ts
@@ -33,60 +33,6 @@ describe('class GraphvizInstaller', () => {
 
         expect(brewInstall.mock.calls.length).toBe(1);
       });
-
-      describe('inputs works', () => {
-        test('graphviz version not seted', async () => {
-          (getInput as jest.Mock).mockReturnValue('');
-          const execSpy = jest.spyOn(exec, 'exec');
-
-          await installer.get();
-
-          expect(execSpy).toBeCalledTimes(2);
-          expect(execSpy.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "brew",
-              Array [
-                "update",
-              ],
-            ]
-          `);
-          expect(execSpy.mock.calls[1]).toMatchInlineSnapshot(`
-            Array [
-              "brew",
-              Array [
-                "install",
-                "graphviz",
-              ],
-            ]
-          `);
-        });
-
-        test('graphviz version seted to "1.1.1"', async () => {
-          (getInput as jest.Mock).mockReturnValue('1.1.1');
-          const execSpy = jest.spyOn(exec, 'exec');
-
-          await installer.get();
-
-          expect(execSpy).toBeCalledTimes(2);
-          expect(execSpy.mock.calls[0]).toMatchInlineSnapshot(`
-            Array [
-              "brew",
-              Array [
-                "update",
-              ],
-            ]
-          `);
-          expect(execSpy.mock.calls[1]).toMatchInlineSnapshot(`
-            Array [
-              "brew",
-              Array [
-                "install",
-                "graphviz@1.1.1",
-              ],
-            ]
-          `);
-        });
-      });
     });
 
     describe('Work on "linux"', () => {


### PR DESCRIPTION
Added support for strict version specification feature in Ubuntu and Windows(non-macos) Runner.

```yaml
- uses: ts-graphviz/setup-graphviz@v1.1.0-1
  with:
    ubuntu-graphviz-version: '2.42.2-3build2'
    ubuntu-libgraphvizdev-version: '2.42.2-3build2'
    windows-graphviz-version: '2.49.3'
```

fix #283

#### TODO

- [x] documentation