### PR TITLE
force auto-install on linux systems

### DIFF
--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -36,6 +36,7 @@ export class GraphvizInstaller {
     await exec('sudo', [
       'apt-get',
       'install',
+      '-y',
       graphvizVersion ? `graphviz=${graphvizVersion}` : 'graphviz',
       // https://github.com/pygraphviz/pygraphviz/issues/163#issuecomment-570770201
       libgraphvizdevVersion ? `libgraphviz-dev=${libgraphvizdevVersion}` : 'libgraphviz-dev',


### PR DESCRIPTION
Maybe I am dumb and maybe there is another way of doing this, but when using this on linux vm, `apt-get install graphviz libgraphviz-dev pkg-config` is expecting an input for `(y)es`, so this approach ensures, it is always defaulting to yes, so the build is not hanging.