### PR TITLE
Add skip repository update flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ you can specify a specific version for each operating system (not macOS).
     ubuntu-graphviz-version: '2.42.2-3build2'
     # libgraphviz-dev version on Ubuntu.
     ubuntu-libgraphvizdev-version: '2.42.2-3build2'
+    # Skip to run apt update command on Ubuntu.
+    ubuntu-skip-apt-update: 'true' # defalt false
     #  graphviz version on Windows.
     windows-graphviz-version: '2.49.3'
+    # Skip to run brew update command on macOS.
+    macos-skip-brew-update: 'true' # defalt false
 ```
 
 ## See Also

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,11 @@ branding:
   icon: arrow-down-circle
   color: gray-dark
 inputs:
+  ubuntu-skip-apt-update:
+    description: |-
+      Skip to run apt update command on Ubuntu.
+    required: false
+    default: 'false'
   ubuntu-graphviz-version:
     description: |-
       graphviz version on Ubuntu.
@@ -13,6 +18,11 @@ inputs:
     description: |-
       libgraphviz-dev version on Ubuntu.
     required: false
+  macos-skip-brew-update:
+    description: |-
+      Skip to run brew update command on macOS.
+    required: false
+    default: 'false'
   windows-graphviz-version:
     description: |-
       graphviz version on Windows.

--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -1,4 +1,4 @@
-import { getInput } from '@actions/core';
+import { getBooleanInput, getInput } from '@actions/core';
 import { exec } from '@actions/exec';
 
 export class GraphvizInstaller {
@@ -22,7 +22,10 @@ export class GraphvizInstaller {
   }
 
   private async brewInstall() {
-    await exec('brew', ['update']);
+    const skipBrewUpdate = getBooleanInput('macos-skip-brew-update');
+    if (skipBrewUpdate === false) {
+      await exec('brew', ['update']);
+    }
     await exec('brew', [
       'install',
       'graphviz',
@@ -30,9 +33,12 @@ export class GraphvizInstaller {
   }
 
   private async getAptInstall() {
+    const skipAptUpdate = getBooleanInput('ubuntu-skip-apt-update');
     const graphvizVersion = getInput('ubuntu-graphviz-version');
     const libgraphvizdevVersion = getInput('ubuntu-libgraphvizdev-version');
-    await exec('sudo', ['apt-get', 'update']);
+    if (skipAptUpdate === false) {
+      await exec('sudo', ['apt-get', 'update']);
+    }
     await exec('sudo', [
       'apt-get',
       'install',

--- a/src/__tests__/GraphvizInstaller.spec.ts
+++ b/src/__tests__/GraphvizInstaller.spec.ts
@@ -1,7 +1,7 @@
 jest.mock('@actions/core');
 jest.mock('@actions/exec');
 
-import { getInput } from '@actions/core';
+import { getInput, getBooleanInput } from '@actions/core';
 import * as exec from '@actions/exec';
 import { GraphvizInstaller } from '../GraphvizInstaller';
 
@@ -33,6 +33,51 @@ describe('class GraphvizInstaller', () => {
 
         expect(brewInstall.mock.calls.length).toBe(1);
       });
+
+      describe('inputs works', () => {
+        test('default', async () => {
+          (getBooleanInput as jest.Mock).mockReturnValue(false);
+          const execSpy = jest.spyOn(exec, 'exec');
+
+          await installer.get();
+
+          expect(execSpy).toBeCalledTimes(2);
+          expect(execSpy.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "brew",
+              Array [
+                "update",
+              ],
+            ]
+          `);
+          expect(execSpy.mock.calls[1]).toMatchInlineSnapshot(`
+            Array [
+              "brew",
+              Array [
+                "install",
+                "graphviz",
+              ],
+            ]
+          `);
+        });
+        test('skip brew update', async () => {
+          (getBooleanInput as jest.Mock).mockReturnValue(true);
+          const execSpy = jest.spyOn(exec, 'exec');
+
+          await installer.get();
+
+          expect(execSpy).toBeCalledTimes(1);
+          expect(execSpy.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "brew",
+              Array [
+                "install",
+                "graphviz",
+              ],
+            ]
+          `);
+        });
+      });
     });
 
     describe('Work on "linux"', () => {
@@ -51,8 +96,30 @@ describe('class GraphvizInstaller', () => {
       });
 
       describe('inputs works', () => {
+        test('skip apt update', async () => {
+          (getBooleanInput as jest.Mock).mockReturnValue(true);
+          const execSpy = jest.spyOn(exec, 'exec');
+
+          await installer.get();
+
+          expect(execSpy).toBeCalledTimes(1);
+          expect(execSpy.mock.calls[0]).toMatchInlineSnapshot(`
+            Array [
+              "sudo",
+              Array [
+                "apt-get",
+                "install",
+                "graphviz",
+                "libgraphviz-dev",
+                "pkg-config",
+              ],
+            ]
+          `);
+        });
+
         test('graphviz version not seted', async () => {
           (getInput as jest.Mock).mockReturnValue('');
+          (getBooleanInput as jest.Mock).mockReturnValue(false);
           const execSpy = jest.spyOn(exec, 'exec');
 
           await installer.get();
@@ -92,6 +159,7 @@ describe('class GraphvizInstaller', () => {
                 return '';
             }
           });
+          (getBooleanInput as jest.Mock).mockReturnValue(false);
           const execSpy = jest.spyOn(exec, 'exec');
 
           await installer.get();
@@ -129,6 +197,7 @@ describe('class GraphvizInstaller', () => {
                 return '';
             }
           });
+          (getBooleanInput as jest.Mock).mockReturnValue(false);
           const execSpy = jest.spyOn(exec, 'exec');
 
           await installer.get();
@@ -166,6 +235,7 @@ describe('class GraphvizInstaller', () => {
                 return '';
             }
           });
+          (getBooleanInput as jest.Mock).mockReturnValue(false);
           const execSpy = jest.spyOn(exec, 'exec');
 
           await installer.get();


### PR DESCRIPTION
A flag to specify whether or not to update the package manager's repositories, allowing users to arbitrarily choose whether or not to update.

This fixes the following issues

fix #457 