### PR TITLE
Upgrade node library on MacOS

### DIFF
--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -25,6 +25,7 @@ export class GraphvizInstaller {
     const skipBrewUpdate = getBooleanInput("macos-skip-brew-update");
     if (skipBrewUpdate === false) {
       await exec("brew", ["update"]);
+      await exec("brew", ["upgrade", "node"]);
     }
     await exec("brew", ["install", "graphviz"]);
   }


### PR DESCRIPTION
Updating brew doesn't ensure that packages already on the image will actually get upgraded.  To ensure that graphviz has a current install of node to work with, run brew upgrade node after brew update.

This should fix #578, but I haven't been able to figure out how to validate the run myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved installation process on macOS by upgrading Node.js automatically before installing Graphviz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->