### PR TITLE
Remove apt-get cache clear scripts from GraphvizInstaller

### DIFF
--- a/src/GraphvizInstaller.ts
+++ b/src/GraphvizInstaller.ts
@@ -34,14 +34,6 @@ export class GraphvizInstaller {
     const graphvizVersion = getInput("ubuntu-graphviz-version");
     const libgraphvizdevVersion = getInput("ubuntu-libgraphvizdev-version");
     if (skipAptUpdate === false) {
-      await exec("sudo", ["apt-get", "clean"]);
-      // https://github.com/actions/runner-images/issues/9733#issuecomment-2074565599
-      await exec("sudo", [
-        "sudo",
-        "rm",
-        "/etc/apt/sources.list.d/microsoft-prod.list",
-      ]);
-
       await exec("sudo", ["apt-get", "update"]);
     }
     await exec("sudo", [

--- a/src/__tests__/GraphvizInstaller.spec.ts
+++ b/src/__tests__/GraphvizInstaller.spec.ts
@@ -166,21 +166,6 @@ describe("class GraphvizInstaller", () => {
                 "sudo",
                 [
                   "apt-get",
-                  "clean",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "sudo",
-                  "rm",
-                  "/etc/apt/sources.list.d/microsoft-prod.list",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "apt-get",
                   "update",
                 ],
               ],
@@ -217,21 +202,6 @@ describe("class GraphvizInstaller", () => {
 
           expect(execSpy.mock.calls).toMatchInlineSnapshot(`
             [
-              [
-                "sudo",
-                [
-                  "apt-get",
-                  "clean",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "sudo",
-                  "rm",
-                  "/etc/apt/sources.list.d/microsoft-prod.list",
-                ],
-              ],
               [
                 "sudo",
                 [
@@ -274,21 +244,6 @@ describe("class GraphvizInstaller", () => {
                 "sudo",
                 [
                   "apt-get",
-                  "clean",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "sudo",
-                  "rm",
-                  "/etc/apt/sources.list.d/microsoft-prod.list",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "apt-get",
                   "update",
                 ],
               ],
@@ -323,21 +278,6 @@ describe("class GraphvizInstaller", () => {
 
           expect(execSpy.mock.calls).toMatchInlineSnapshot(`
             [
-              [
-                "sudo",
-                [
-                  "apt-get",
-                  "clean",
-                ],
-              ],
-              [
-                "sudo",
-                [
-                  "sudo",
-                  "rm",
-                  "/etc/apt/sources.list.d/microsoft-prod.list",
-                ],
-              ],
               [
                 "sudo",
                 [


### PR DESCRIPTION
This pull request removes the scripts for clearing the apt-get cache from the GraphvizInstaller class. These scripts were initiating unnecessary cleanup operations and are no longer needed.

The following background information supports this change:

- On self-hosted runners, there are instances where files related to apt-get cannot be deleted with sudo privileges. For more details, see issue #608.
- The issue where apt-get update would fail in GitHub Actions has been permanently resolved. For further information, refer to issue https://github.com/actions/runner-images/issues/9733.

These developments have made the cleanup scripts redundant, hence their removal in this update.

fix #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the installation process for Graphviz by streamlining system updates and cleanup steps.
- **Tests**
	- Updated tests to align with the refined installation procedures for Graphviz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->