### PR TITLE
Update for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,5 +8,10 @@ jobs:
   release:
     name: Release GitHub Actions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
+#      - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
+       - uses: JasonEtco/build-and-tag-action@v2
+         env:
+           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-#      - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
-       - uses: JasonEtco/build-and-tag-action@v2
-         env:
-           GITHUB_TOKEN: ${{ github.token }}
+      - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
+       #- uses: JasonEtco/build-and-tag-action@v2
+       #  env:
+       #    GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
       contents: write
     steps:
       - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
+        with:
+          ORIGINAL_TAG_PREFIX: source
        #- uses: JasonEtco/build-and-tag-action@v2
        #  env:
        #    GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: technote-space/release-github-actions@052f205daf62dff0c3ece009f07b38f3ec83e01a # v8.0.3
         with:
-          ORIGINAL_TAG_PREFIX: source
+          ORIGINAL_TAG_PREFIX: source/
        #- uses: JasonEtco/build-and-tag-action@v2
        #  env:
        #    GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,11 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-      - name: Set Node.js 20.x
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+#        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+        uses: actions/checkout@v6
+      - name: Set Node.js 24.x
+#        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -25,11 +27,11 @@ jobs:
     needs: check
     steps:
     - name: Checkout
-      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-    - name: Set Node.js 20.x
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      uses: actions/checkout@v6
+    - name: Set Node.js 24.x
+      uses: actions/setup-node@v6
       with:
-        node-version: 20.x
+        node-version: 24.x
         cache: yarn
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -44,18 +46,18 @@ jobs:
     needs: check
     steps:
       - name: Checkout
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-      - name: Set Node.js 20.x
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/checkout@v6
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
       - name: Upload Artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@v7
         with:
           name: lib
           path: lib
@@ -72,16 +74,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-      - name: Set Node.js 20.x
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/checkout@v6
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Download Artifact
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@v8
+        with:
+          path: lib
       - name: Run Integration Tests
         uses: ./
       - name: Graphviz test

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,9 +13,7 @@ jobs:
           node-version: 24.x
           cache: yarn
       - name: Install Dependencies
-        run: yarn install
-      - name: Print yarn.lock
-        run: grep -A 4 node yarn.lock
+        run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint
       - name: TypeCheck

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Print yarn.lock
-        run: grep node yarn.lock
+        run: grep -A 4 node yarn.lock
       - name: Lint
         run: yarn lint
       - name: TypeCheck

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,7 +13,9 @@ jobs:
           node-version: 24.x
           cache: yarn
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
+      - name: Print yarn.lock
+        run: grep node yarn.lock
       - name: Lint
         run: yarn lint
       - name: TypeCheck

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -83,6 +83,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          name: lib
           path: lib
       - name: Run Integration Tests
         uses: ./

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,11 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-#        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set Node.js 24.x
-#        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: yarn
@@ -27,9 +25,9 @@ jobs:
     needs: check
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set Node.js 24.x
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24.x
         cache: yarn
@@ -46,9 +44,9 @@ jobs:
     needs: check
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: yarn
@@ -57,7 +55,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lib
           path: lib
@@ -74,16 +72,16 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Download Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: lib
       - name: Run Integration Tests

--- a/action.yaml
+++ b/action.yaml
@@ -29,5 +29,5 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: lib/main.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.1",
-    "@types/node": "^20.12.7",
+    "@types/node": "^24.x",
     "typescript": "^5.4.5",
     "vitest": "^1.5.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,12 +318,12 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
-"@types/node@^20.12.7":
-  version "20.12.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
-  integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
+"@types/node@^24.x":
+  version "24.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~7.16.0"
 
 "@vitest/expect@1.5.1":
   version "1.5.1"


### PR DESCRIPTION
in order to continue using this Action in GitHub workflows after Sept 16th 2026, when Node.js 20 will be removed from the runners, and without special handling after June 2nd when actions will be "forced to run  to run with Node.js 24 by default".

You will need to merge this and make a release before Sep 16th because the `release.yml` workflow of this repo uses `technote-space/release-github-actions` which uses the even older Node.js 16. That action has not been updated in 3 years. (The only alternative I found, `JasonEtco/build-and-tag-action`, hasn't been touched in 2 years and uses Node.js 20.) Fortunately that old action is only needed to build a release of this action.

I thought about modifying the release.yml workflow to explicitly perform the steps needed to release an action but, so far, I have been unable to find documentation about what those steps are or how the gh-actions branch is involved. One document I have found talks about manual steps saying

> 1. Navigate to the action metadata file in your repository (action.yml), and you'll see a banner to publish the action to GitHub Marketplace. Click Draft a release.
>
> 2. Under "Release Action", select Publish this Action to the GitHub Marketplace. 

This would be fine but don't see a banner and I don't see a Publish this Action button when editing a release in my fork.

The other document I found tells you to use `JasonEtco/build-and-tag-action`.

This includes an update to `release.yml` to preserve the original release triggering tag in the source branch by prefixing it with `source/`.

Fixes #654.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows and action metadata to use newer GitHub Actions releases.
  * Upgraded the Node runtime used by workflows from 20.x to 24.x, including development type definitions.
  * Updated build and integration jobs to use newer artifact upload/download actions.
  * Added job-level permissions for releases and expanded the release workflow with commented example steps.

* **Bug Fixes**
  * Improved macOS Graphviz installation by adding Homebrew “trust” steps before installing Graphviz.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->